### PR TITLE
Integrate Geocoding API 

### DIFF
--- a/shops.py
+++ b/shops.py
@@ -1,10 +1,11 @@
-from __future__ import print_function # In python 2.7
+from __future__ import print_function  # In python 2.7
 
 from flask import redirect, request, url_for, render_template
 from flask.views import MethodView
 import bgmodel
 import sys
 import requests
+
 
 class Shops(MethodView):
     def get(self):
@@ -14,18 +15,37 @@ class Shops(MethodView):
         """
         model = bgmodel.get_model()
         settings = bgmodel.get_settings()
-        shops = [dict(name=row[0], street=row[1], city=row[2], state=row[3], zip=row[4], open_hr=row[5],
-                        close_hr=row[6], phone=row[7], drink=row[8], rating=row[9], website=row[10]) for row in model.select()]
+        shops = [
+            dict(
+                name=row[0],
+                street=row[1],
+                city=row[2],
+                state=row[3],
+                zip=row[4],
+                open_hr=row[5],
+                close_hr=row[6],
+                phone=row[7],
+                drink=row[8],
+                rating=row[9],
+                website=row[10],
+            )
+            for row in model.select()
+        ]
         key_row = settings.select()[0]
         api_keys = dict(google=key_row[0])
         shop_locations = []
         for shop in shops:
-            address = shop["street"]+"+"+shop["city"]+"+"+shop["state"]
-            response = requests.get(("https://maps.googleapis.com/maps/api/geocode/json?address={}&key={}").format(address, api_keys['google']))
+            address = shop["street"] + "+" + shop["city"] + "+" + shop["state"]
+            response = requests.get(
+                (
+                    "https://maps.googleapis.com/maps/api/geocode/json?address={}&key={}"
+                ).format(address, api_keys["google"])
+            )
             geocode_result = response.json()["results"][0]["geometry"]["location"]
             shop_locations.append(geocode_result)
-        return render_template('shops.html', shops=shops, api_keys=api_keys, shop_locations=shop_locations)
-
+        return render_template(
+            "shops.html", shops=shops, api_keys=api_keys, shop_locations=shop_locations
+        )
 
     def post(self):
         """
@@ -33,5 +53,5 @@ class Shops(MethodView):
         :return: renders the shops.html page on return
         """
         model = bgmodel.get_model()
-        model.delete(request.form['name'])
-        return redirect(url_for('shops'))
+        model.delete(request.form["name"])
+        return redirect(url_for("shops"))

--- a/shops.py
+++ b/shops.py
@@ -19,12 +19,11 @@ class Shops(MethodView):
         key_row = settings.select()[0]
         api_keys = dict(google=key_row[0])
         shop_locations = []
-        # for shop in shops:
-        address = shops[0]["street"]+"+"+shops[0]["city"]+"+"+shops[0]["state"]
-        response = requests.get("https://maps.googleapis.com/maps/api/geocode/json?address=address&key="+api_keys['google'])
-        test = response.json()["results"][0]["geometry"]["location"]
-        shop_locations.append(test)
-
+        for shop in shops:
+            address = shop["street"]+"+"+shop["city"]+"+"+shop["state"]
+            response = requests.get(("https://maps.googleapis.com/maps/api/geocode/json?address={}&key={}").format(address, api_keys['google']))
+            geocode_result = response.json()["results"][0]["geometry"]["location"]
+            shop_locations.append(geocode_result)
         return render_template('shops.html', shops=shops, api_keys=api_keys, shop_locations=shop_locations)
 
 
@@ -35,5 +34,4 @@ class Shops(MethodView):
         """
         model = bgmodel.get_model()
         model.delete(request.form['name'])
-
         return redirect(url_for('shops'))

--- a/shops.py
+++ b/shops.py
@@ -4,6 +4,7 @@ from flask import redirect, request, url_for, render_template
 from flask.views import MethodView
 import bgmodel
 import sys
+import requests
 
 class Shops(MethodView):
     def get(self):
@@ -17,7 +18,15 @@ class Shops(MethodView):
                         close_hr=row[6], phone=row[7], drink=row[8], rating=row[9], website=row[10]) for row in model.select()]
         key_row = settings.select()[0]
         api_keys = dict(google=key_row[0])
-        return render_template('shops.html', shops=shops, api_keys=api_keys)
+        shop_locations = []
+        # for shop in shops:
+        address = shops[0]["street"]+"+"+shops[0]["city"]+"+"+shops[0]["state"]
+        response = requests.get("https://maps.googleapis.com/maps/api/geocode/json?address=address&key="+api_keys['google'])
+        test = response.json()["results"][0]["geometry"]["location"]
+        shop_locations.append(test)
+
+        return render_template('shops.html', shops=shops, api_keys=api_keys, shop_locations=shop_locations)
+
 
     def post(self):
         """

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -75,46 +75,13 @@
 
     // List of markers to appear on the map
     var marker = [];
-    // Creates a constructor object to access the geocoding service
-    var geocoder = new google.maps.Geocoder();
     // Stores the coordinates for each shop location
     var shop_locations = {{ shop_locations | safe }};
-    console.log(shop_locations);
-    // console.log("Shop locations=", shop_locations[0]);
-
-    /* Given the address received from the HTML form, this function stores the corresponding latitude and longitude values as a LatLng object. */
-    // function geocodeAddress(address, _callback) {
-    //   geocoder.geocode({ 'address': address }, function (results, status) {
-    //     if (status == 'OK') {
-    //       var coordinates = results[0].geometry.location;
-    //       // Stores the resulting coordinates in an array 
-    //       shop_locations.push(coordinates);
-    //       console.log("Coordinates (result of geocode)=", coordinates);
-    //       console.log("Shop locations (after push)=", shop_locations[0]);
-    //       // Creates a marker at the coordinates retrieved from the geocode
-    //       marker.push(
-    //         new google.maps.Marker({
-    //           position: coordinates,
-    //           map: map,
-    //           icon: icon
-    //         }));
-    //       _callback();
-    //     } else {
-    //       alert('Geocode was not sucessful for the following reason: ' + status);
-    //     }
-    //   });
-    // }
-    
     var infowindow = [];
     var obj;
     var mapContent;
 
   {% for shop in shops %}
-    // var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
-    // console.log("Address=", address);
-    // geocodeAddress(address);
-    // console.log("Shop locations (after geocodeAddress is called)=", shop_locations[0]);
-    
     mapContent =
       '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
         '<div class="card-body px-0 pt-2 pb-0">' +
@@ -137,8 +104,6 @@
       scaledSize: new google.maps.Size(32, 32),
     }
 
-    console.log("Before marker ", shop_locations);
-    console.log("shop locations ", shop_locations[{{ loop.index - 1 }}]);
     marker.push(
       new google.maps.Marker({
         position: shop_locations[{{ loop.index - 1 }}],

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -25,12 +25,12 @@
                   <div class="row">
                     <form action="{{ url_for('shops') }}" method=post>
                       <input type="hidden" name="name" value="{{ shop.name }}">
-                      <button type="submit" class="btn btn-light btn-block" value="Form" >Delete</button>
+                      <button type="submit" class="btn btn-light btn-block" value="Form">Delete</button>
                     </form>
                   </div>
                 </div>
                 <div class="col-sm-7">
-                  <a  class="name_links" href="{{ shop.website }}">{{ loop.index }}. {{ shop.name }}</a> <br>
+                  <a class="name_links" href="{{ shop.website }}">{{ loop.index }}. {{ shop.name }}</a> <br>
                   {% for i in range(shop.rating) %}
                   <span class="fa fa-star checked"></span>
                   {% endfor %}
@@ -122,16 +122,16 @@
       })
     );
 
-    marker[{{ loop.index }} - 1].addListener('click', function() {
-      for(j = 0; j < infowindow.length; ++j) {
+    marker[{{ loop.index }} - 1].addListener('click', function () {
+      for (j = 0; j < infowindow.length; ++j) {
         infowindow[j].close();
       }
       infowindow[{{ loop.index }} - 1].open(map, marker[{{ loop.index }} - 1]);
     });
 
     obj = document.getElementById("shopid{{ loop.index }}");
-    obj.addEventListener('click', function() {
-      for (j = 0; j < infowindow.length; ++ j) {
+    obj.addEventListener('click', function () {
+      for (j = 0; j < infowindow.length; ++j) {
         infowindow[j].close();
       }
       infowindow[{{ loop.index }} - 1].open(map, marker[{{ loop.index }} - 1]);
@@ -140,7 +140,6 @@
   {% endfor %}
   }
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key={{ api_keys.google }}&callback=initMap"
-async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ api_keys.google }}&callback=initMap" async defer></script>
 
 {% endblock %}

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -71,18 +71,19 @@
       center: { lat: 45.523064, lng: -122.676483 },
       zoom: 12
     });
+
     var geocoder = new google.maps.Geocoder();
     var shop_locations = [];
     var marker = [];
 
-    function codeAddress(address, gmap) {
+    function codeAddress(address) {
       geocoder.geocode({ 'address': address }, function (results, status) {
-        if (status === 'OK') {
+        if (status == 'OK') {
           shop_locations.push(results[0].geometry.location);
           marker.push(
             new google.maps.Marker({
               position: results[0].geometry.location,
-              map: gmap,
+              map: map,
               icon: icon
             }));
         } else {
@@ -97,7 +98,7 @@
 
   {% for shop in shops %}
     var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
-    codeAddress(address, map);
+    codeAddress(address);
     mapContent =
       '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
         '<div class="card-body px-0 pt-2 pb-0">' +

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -66,23 +66,31 @@
 </script>
 
 <script>
+  // Initialize and add the map
   function initMap() {
     var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 45.523064, lng: -122.676483 },
       zoom: 12
     });
 
-    var geocoder = new google.maps.Geocoder();
-    var shop_locations = [];
+    // List of markers to appear on the map
     var marker = [];
+    // Creates a constructor object to access the geocoding service
+    var geocoder = new google.maps.Geocoder();
+    // Stores the coordinates for each shop location
+    var shop_locations = [];
 
-    function codeAddress(address) {
+    /* Given the address received from the HTML form, this function stores the corresponding latitude and longitude values as a LatLng object. */
+    function geocodeAddress(address) {
       geocoder.geocode({ 'address': address }, function (results, status) {
         if (status == 'OK') {
-          shop_locations.push(results[0].geometry.location);
+          var coordinates = results[0].geometry.location;
+          // Stores the resulting coordinates in an array 
+          shop_locations.push(coordinates);
+          // Creates a marker at the coordinates retrieved from the geocode
           marker.push(
             new google.maps.Marker({
-              position: results[0].geometry.location,
+              position: coordinates,
               map: map,
               icon: icon
             }));
@@ -98,7 +106,7 @@
 
   {% for shop in shops %}
     var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
-    codeAddress(address);
+    geocodeAddress(address);
     mapContent =
       '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
         '<div class="card-body px-0 pt-2 pb-0">' +
@@ -153,6 +161,11 @@
   {% endfor %}
   }
 </script>
+<!-- Loads the API from the specified URL
+  * The async attribute allows the browser to render the page while the API loads
+  * The key parameter contains our API key
+  * The callback parameter executes the initMap() function
+-->
 <script src="https://maps.googleapis.com/maps/api/js?key={{ api_keys.google }}&callback=initMap" async defer></script>
 
 {% endblock %}

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -66,42 +66,54 @@
 </script>
 
 <script>
-  var map;
   function initMap() {
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: {lat: 45.523064, lng: -122.676483},
+    var map = new google.maps.Map(document.getElementById('map'), {
+      center: { lat: 45.523064, lng: -122.676483 },
       zoom: 12
-    })
-
+    });
+    var geocoder = new google.maps.Geocoder();
+    var shop_locations = [];
     var marker = [];
+
+    function codeAddress(address, gmap) {
+      geocoder.geocode({ 'address': address }, function (results, status) {
+        if (status === 'OK') {
+          shop_locations.push(results[0].geometry.location);
+          marker.push(
+            new google.maps.Marker({
+              position: results[0].geometry.location,
+              map: gmap,
+              icon: icon
+            }));
+        } else {
+          alert('Geocode was not sucessful for the following reason: ' + status);
+        }
+      });
+    }
+    
     var infowindow = [];
     var obj;
     var mapContent;
-    var temp_locations = [
-      {lat: 45.5113875, lng: -122.6877654},
-      {lat: 45.5076607, lng: -122.7330264},
-      {lat: 45.527706, lng: -122.661974},
-      {lat: 45.517461, lng: -122.655665},
-      {lat: 45.5044377, lng: -122.7129468}
-    ]
 
   {% for shop in shops %}
+    var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
+    codeAddress(address, map);
     mapContent =
-    '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
-      '<div class="card-body px-0 pt-2 pb-0">' +
-        '<div class="row">' +
-          '<div class="col">' +
-            '<h5 class="card-text">{{ loop.index }}. {{ shop.name }}</h5>';
-              for(var j = 0; j < {{ shop.rating }}; ++j) {
-                mapContent += '<span class="fa fa-star checked"></span>';
-              }
-              for(var j = 0; j < (5 - {{ shop.rating }}); ++j) {
-                mapContent += '<span class="fa fa-star"></span>';
-              }
+      '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
+        '<div class="card-body px-0 pt-2 pb-0">' +
+          '<div class="row">' +
+            '<div class="col">' +
+              '<h5 class="card-text">{{ loop.index }}. {{ shop.name }}</h5>';
+                for (var j = 0; j < {{ shop.rating }}; ++j) {
+                  mapContent += '<span class="fa fa-star checked"></span>';
+                }
+                for (var j = 0; j < (5 - {{ shop.rating }}); ++j) {
+                  mapContent += '<span class="fa fa-star"></span>';
+                }
+              '</div>' +
+            '</div>' +
           '</div>' +
-        '</div>' +
-      '</div>' +
-    '</div>';
+        '</div>';
 
     var icon = {
       url: '/static/images/favicon.ico',
@@ -110,10 +122,10 @@
 
     marker.push(
       new google.maps.Marker({
-        position: temp_locations[{{ loop.index - 1 }}],
+        position: shop_locations[{{ loop.index - 1 }}],
         map: map,
         icon: icon
-      })
+        })
     );
 
     infowindow.push(

--- a/templates/shops.html
+++ b/templates/shops.html
@@ -78,35 +78,43 @@
     // Creates a constructor object to access the geocoding service
     var geocoder = new google.maps.Geocoder();
     // Stores the coordinates for each shop location
-    var shop_locations = [];
+    var shop_locations = {{ shop_locations | safe }};
+    console.log(shop_locations);
+    // console.log("Shop locations=", shop_locations[0]);
 
     /* Given the address received from the HTML form, this function stores the corresponding latitude and longitude values as a LatLng object. */
-    function geocodeAddress(address) {
-      geocoder.geocode({ 'address': address }, function (results, status) {
-        if (status == 'OK') {
-          var coordinates = results[0].geometry.location;
-          // Stores the resulting coordinates in an array 
-          shop_locations.push(coordinates);
-          // Creates a marker at the coordinates retrieved from the geocode
-          marker.push(
-            new google.maps.Marker({
-              position: coordinates,
-              map: map,
-              icon: icon
-            }));
-        } else {
-          alert('Geocode was not sucessful for the following reason: ' + status);
-        }
-      });
-    }
+    // function geocodeAddress(address, _callback) {
+    //   geocoder.geocode({ 'address': address }, function (results, status) {
+    //     if (status == 'OK') {
+    //       var coordinates = results[0].geometry.location;
+    //       // Stores the resulting coordinates in an array 
+    //       shop_locations.push(coordinates);
+    //       console.log("Coordinates (result of geocode)=", coordinates);
+    //       console.log("Shop locations (after push)=", shop_locations[0]);
+    //       // Creates a marker at the coordinates retrieved from the geocode
+    //       marker.push(
+    //         new google.maps.Marker({
+    //           position: coordinates,
+    //           map: map,
+    //           icon: icon
+    //         }));
+    //       _callback();
+    //     } else {
+    //       alert('Geocode was not sucessful for the following reason: ' + status);
+    //     }
+    //   });
+    // }
     
     var infowindow = [];
     var obj;
     var mapContent;
 
   {% for shop in shops %}
-    var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
-    geocodeAddress(address);
+    // var address = "{{ shop.street }}, {{ shop.city }}, {{ shop.state }} {{ shop.zip }}"
+    // console.log("Address=", address);
+    // geocodeAddress(address);
+    // console.log("Shop locations (after geocodeAddress is called)=", shop_locations[0]);
+    
     mapContent =
       '<div class="card transparent-border" id="mapid{{ loop.index }}">' +
         '<div class="card-body px-0 pt-2 pb-0">' +
@@ -129,6 +137,8 @@
       scaledSize: new google.maps.Size(32, 32),
     }
 
+    console.log("Before marker ", shop_locations);
+    console.log("shop locations ", shop_locations[{{ loop.index - 1 }}]);
     marker.push(
       new google.maps.Marker({
         position: shop_locations[{{ loop.index - 1 }}],


### PR DESCRIPTION
## Overview
Currently, Google Maps is integrated with a hard-coded list of dictionaries containing coordinates, since the Maps API only takes longitude and latitude as input for placing markers (representing our tea shops) on the map. 

The Geocoding API takes an address as form input from the user, and translates it into coordinates for the Maps API to consume. This improves user experience since they will not have to muck around with longitude and latitude themselves. 

### Issues
* If I didn't include `marker.push()` code in the `codeAddress` function _and_ in its original place within the `{% for shop in shops %}` loop, the markers didn't populate on the map. 
* When you click on a marker on the map, it no longer populates a window containing the shop's name and rating. 
#### Resolved
It seems that variables updated in the `geocodeAddress()` method were not recognized outside of the method. To resolve the issues this was creating, we removed the JavaScript implementation, and replaced it with a Python implementation. We were able to get this working successfully. 

